### PR TITLE
Scanner updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -576,6 +587,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +612,7 @@ dependencies = [
  "env_logger",
  "futures",
  "log",
+ "rand",
  "serde",
  "serde_json",
  "signal-hook",
@@ -608,6 +626,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -770,6 +818,12 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ signal-hook-async-std = { version="0.2"}
 signal-hook = {version="0.3"}
 futures = {version="0.3"}
 base64 = {version="0.13"}
+rand = {version="0.8"}
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,57 @@
 # pscan
 
-`pscan` is a TCP port scanner, which can be used to scan hosts/networks for
-open TCP ports. Results can be printed in human readable or JSON format.
+`pscan` is a TCP port scanner, which can be used to scan hosts/networks for open
+TCP ports. Results can be printed in human readable or JSON format.
 
 ## Building
 
-`pscan` is written with [rust](http://www.rust-lang.org/). If you have rust toolchain installed
-you can compile it with `cargo build --release`. Currently Linux and Mac OS are
-supported platforms.
+`pscan` is written with [rust](http://www.rust-lang.org/). If you have rust
+toolchain installed you can compile it with `cargo build --release`. Currently
+Linux and Mac OS are supported platforms.
 
 ## Usage
 
 Use `pscan --help` to get help for command line parameters:
 
 ```
-TCP port scanner 0.1.0
-
 USAGE:
-    pscan [FLAGS] [OPTIONS]
-
-FLAGS:
-    -h, --help              Prints help information
-    -B, --read-banner       Try to read up to read-banner-size bytes (with read-banner-timeout) when connection is
-                            established
-    -R, --retry-on-error    Retry scan a few times on (possible transient) network error
-    -V, --version           Prints version information
-    -v, --verbose           Verbose output
+    pscan [OPTIONS]
 
 OPTIONS:
-    -b, --concurrent-scans <concurrent-scans>          Number of concurrent scans to run [default: 100]
-    -C, --config <config>                              Read configuration from given JSON file
-    -e, --exclude <exclude>                            Comma -separated list of addresses to exclude from scanning
-    -j, --json <json>                                  Write output as JSON into given file, - to write to stdout
-    -p, --ports <ports>                                Ports to scan [default: 1-100]
+    -b, --concurrent-scans <concurrent-scans>
+            Number of concurrent scans to run [default: 100]
+
+    -B, --read-banner
+            Try to read up to read-banner-size bytes (with read-banner-timeout) when connection is
+            established
+
+    -C, --config <config>
+            Read configuration from given JSON file
+
+    -e, --exclude <exclude>
+            Comma -separated list of addresses to exclude from scanning
+
+    -h, --help
+            Print help information
+
+    -H, --concurrent-hosts <concurrent-hosts>
+            Number of hosts to scan concurrently. Can be used to limit the number of hosts to scan at
+            the same time, if number of concurrent threads is large. If no value is set, number of
+            concurrent scans is used
+
+    -j, --json <json>
+            Write output as JSON into given file, - to write to stdout
+
+    -p, --ports <ports>
+            Ports to scan [default: 1-100]
+
+    -r, --try-count <try-count>
+            Number of times to try a port which receives no response (including the initial try)
+            [default: 2]
+
+    -R, --retry-on-error
+            Retry scan a few times on (possible transient) network error
+
         --read-banner-size <read-banner-size>
             Maximum number of bytes to read when reading banner from open port [default: 256]
 
@@ -43,50 +62,71 @@ OPTIONS:
             Address(es) of the host(s) to scan, IP addresses, or CIDRs separated by comma
 
     -T, --timeout <timeout>
-            Timeout in ms to wait for response before determening port as closed/firewalled [default: 1000]
+            Timeout in ms to wait for response before determening port as closed/firewalled
+            [default: 1000]
 
-    -r, --try-count <try-count>
-            Number of times to try a port which receives no response (including the initial try) [default: 2]
+    -v, --verbose
+            Verbose output
+
+    -V, --version
+            Print version information
 ```
 
-To scan hosts or networks, give the addresses of targets with `--target` command line option. The targets should be comma -separated list of
-IP addresses or networks in CIRD notataion (address/mask). Single hosts can be excluded from scan using `--exclude` options. Ports to scan can be defined with `--ports` option. The `--timeout` option specifies how long to wait (in ms) for connection to establish before
-marking the port as filtered.
+To scan hosts or networks, give the addresses of targets with `--target` command
+line option. The targets should be comma -separated list of IP addresses or
+networks in CIRD notataion (address/mask). Single hosts can be excluded from
+scan using `--exclude` options. Ports to scan can be defined with `--ports`
+option. The `--timeout` option specifies how long to wait (in ms) for connection
+to establish before marking the port as filtered.
 
-To scan all ports from "192.168.1.0/24" network and hosts "10.0.0.1" and "10.0.0.2" except host "192.168.1.100", run `pscan` with
+To scan all ports from "192.168.1.0/24" network and hosts "10.0.0.1" and
+"10.0.0.2" except host "192.168.1.100", run `pscan` with
+
 ```
 pscan --target 192.168.1.0/24,10.0.0.1,10.0.0.2 --exclude 192.168.1.100 --ports 1-65535
 ```
 
-Number of concurrent scans, that is how many ports are scanned at once, can be controlled with `--concurrent-scans` option. Note that
-increasing this number above the "max open files" ulimit will cause error, this limit can be increased with `ulimit -n` command.
+Number of concurrent scans can be controlled with `--concurrent-scans` option.
+Note that increasing this number above the "max open files" ulimit will cause
+error, this limit can be increased with `ulimit -n` command. The
+`--concurrent-hosts` option can be used to limit the number of hosts to scan at
+the same time. By default pscan spreads scanning over multiple hosts, this
+option can be used to limit how many hosts to scan at the same time.
 
-If `--read-banner` flag is set, `pcsan` will try to read data from open ports and will show any data received once scan is complete. The
-`--read-banner-size` and `--read-banner-timeout` options can be used to define the maximum number of bytes to read and how long to wait for
-data.
+If `--read-banner` flag is set, `pcsan` will try to read data from open ports
+and will show any data received once scan is complete. The `--read-banner-size`
+and `--read-banner-timeout` options can be used to define the maximum number of
+bytes to read and how long to wait for data.
 
-By default, ports for which no response is received are retried once before marking them as filtered. With `--try-count` option the number of
-times connection is tried can be changed.
+By default, ports for which no response is received are retried once before
+marking them as filtered. With `--try-count` option the number of times
+connection is tried can be changed.
 
 ### Configuration file
 
-The configuration options can also be given in JSON -formated confguration file. To read the configuration file use `--config` command line
-option. The configuration file should contain JSON object whose fields are command line options:
+The configuration options can also be given in JSON -formated confguration file.
+To read the configuration file use `--config` command line option. The
+configuration file should contain JSON object whose fields are command line
+options:
+
 ```json
 {
-    "target": "192.168.1.0/24, 10.0.0.1, 10.0.0.2",
-    "exclude": "192.168.1.100",
-    "ports": "22,80,8080,443,8443,9000-9005",
-    "read-banner": true
+  "target": "192.168.1.0/24, 10.0.0.1, 10.0.0.2",
+  "exclude": "192.168.1.100",
+  "ports": "22,80,8080,443,8443,9000-9005",
+  "read-banner": true
 }
 ```
 
-Options set on command line will overwrite options set on configuration file. Default values
-for command line options are used for options not specified on configuration file.
+Options set on command line will overwrite options set on configuration file.
+Default values for command line options are used for options not specified on
+configuration file.
 
 ## Ouput
 
-By default `pscan` will print summary on command line after a scan has been completed:
+By default `pscan` will print summary on command line after a scan has been
+completed:
+
 ```
 jtt@jimmy:~/pscan$ ./pscan -t 192.168.1.0/24 -p 1-65535 -b 1000 -r 2 -B
 Scan complete:
@@ -110,19 +150,22 @@ Scan complete:
 If `--verbose` command line option is given, `pscan` will print information as
 hosts are scanned and summary after scan is completed.
 
-The output of `pscan` can change from time to time and is not meant to be parsed by other programs.
-The JSON output is more stable and can be used to parse the results by other programs.
-
+The output of `pscan` can change from time to time and is not meant to be parsed
+by other programs. The JSON output is more stable and can be used to parse the
+results by other programs.
 
 ### JSON Ouput
 
-With `--json` commmand line option results are printed in JSON format to a file with a given name.
-If `-` is given as file name, the JSON data is written to stdout.
+With `--json` commmand line option results are printed in JSON format to a file
+with a given name. If `-` is given as file name, the JSON data is written to
+stdout.
 
-The results are written as single JSON object followed by newline. When parsing data, well formed
-JSON object should have been received after a line has been read.
+The results are written as single JSON object followed by newline. When parsing
+data, well formed JSON object should have been received after a line has been
+read.
 
 JSON output is as follows:
+
 ```json
 {
   "message": "scan_complete",
@@ -132,18 +175,7 @@ JSON output is as follows:
     {
       "host": "192.168.1.202",
       "open_ports": [
-        22,
-        5514,
-        3000,
-        6789,
-        8080,
-        8081,
-        8843,
-        8443,
-        48668,
-        46122,
-        42762,
-        8086,
+        22, 5514, 3000, 6789, 8080, 8081, 8843, 8443, 48668, 46122, 42762, 8086,
         8880
       ],
       "closed": 65522,
@@ -154,48 +186,30 @@ JSON output is as follows:
     },
     {
       "host": "192.168.1.241",
-      "open_ports": [
-        1443,
-        1843,
-        1400,
-        1410
-      ],
+      "open_ports": [1443, 1843, 1400, 1410],
       "closed": 65293,
       "filtered": 238,
       "banners": {}
     },
     {
       "host": "192.168.1.1",
-      "open_ports": [
-        80,
-        22,
-        443,
-        10001,
-        53
-      ],
+      "open_ports": [80, 22, 443, 10001, 53],
       "closed": 65530,
       "filtered": 0,
       "banners": {}
-    },
+    }
   ]
 }
-
 ```
-| Element | Value |
-| -- | --|
-|message| "type" for the data, currently "`scan_complete`" is the only one supported |
-|numer_of_hosts| Number of hosts scanned|
-|number_of_ports| Number of ports scanned on each host|
-|results| Array of objects, each object containing result for host with at least one open port |
-|result:host| IP Address of scanned host |
-|result:open_ports| Array containing open port numbers |
-|result:closed| Number of closed (for which the remote end replied) ports |
-|result:filtered| Number of filtered (for which we did not receive reply) ports |
-|result:banners| Object containing port number a "key" and data received base64 encoded as value |
 
-
-
-
-
-
-
+| Element           | Value                                                                                |
+| ----------------- | ------------------------------------------------------------------------------------ |
+| message           | "type" for the data, currently "`scan_complete`" is the only one supported           |
+| numer_of_hosts    | Number of hosts scanned                                                              |
+| number_of_ports   | Number of ports scanned on each host                                                 |
+| results           | Array of objects, each object containing result for host with at least one open port |
+| result:host       | IP Address of scanned host                                                           |
+| result:open_ports | Array containing open port numbers                                                   |
+| result:closed     | Number of closed (for which the remote end replied) ports                            |
+| result:filtered   | Number of filtered (for which we did not receive reply) ports                        |
+| result:banners    | Object containing port number a "key" and data received base64 encoded as value      |

--- a/src/config.rs
+++ b/src/config.rs
@@ -525,7 +525,6 @@ impl Config {
                 .concurrent_hosts
                 .unwrap_or_else(|| self.concurrent_scans.unwrap()),
             wait_timeout: self.timeout.unwrap(),
-            enable_adaptive_timing: false,
             retry_on_error: self.retry_on_error.unwrap(),
             try_count: self.try_count.unwrap(),
             read_banner_size,

--- a/src/config.rs
+++ b/src/config.rs
@@ -679,8 +679,6 @@ mod tests {
 
     use cidr::{Cidr, IpCidr};
 
-    use crate::ports::PortIterator;
-
     use super::*;
 
     #[test]
@@ -788,9 +786,11 @@ mod tests {
                 name: "ports",
                 arg: &["--ports", "22"],
                 check: Box::new(|c| {
-                    let mut p = c.ports.unwrap().collect::<Vec<PortIterator>>();
+                    let p = (0..c.ports.as_ref().unwrap().port_count() as usize)
+                        .into_iter()
+                        .map(|i| c.ports.as_ref().unwrap().get(i));
                     assert_eq!(p.len(), 1);
-                    let ports = p.pop().unwrap().collect::<Vec<u16>>();
+                    let ports = p.collect::<Vec<u16>>();
                     assert_eq!(ports.len(), 1);
                     ports[0] == 22
                 }),
@@ -898,9 +898,10 @@ mod tests {
         assert_eq!(addrs.len(), 1);
         assert_eq!(addrs[0], IpCidr::from_str("192.168.1.0/24").unwrap());
 
-        let mut pi = cfg.ports.unwrap().collect::<Vec<PortIterator>>();
-        assert_eq!(pi.len(), 1);
-        let ports = pi.pop().unwrap().collect::<Vec<u16>>();
+        let pi = (0..cfg.ports.as_ref().unwrap().port_count() as usize)
+            .into_iter()
+            .map(|i| cfg.ports.as_ref().unwrap().get(i));
+        let ports = pi.collect::<Vec<u16>>();
         assert_eq!(ports.len(), 2);
         assert!(ports[0] == 1 && ports[1] == 2);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -604,9 +604,9 @@ impl Config {
             }
         };
         let randomize = {
-            if matches.is_present(ARG_RANDOMIZE){
+            if matches.is_present(ARG_RANDOMIZE) {
                 Some(true)
-            } else{
+            } else {
                 self.randomize.or(Some(false))
             }
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,6 @@ pub const ARG_READ_BANNER_SIZE: &str = "read-banner-size";
 pub const ARG_READ_BANNER_TIMEOUT: &str = "read-banner-timeout";
 pub const ARG_READ_BANNER: &str = "read-banner";
 pub const ARG_VERBOSE: &str = "verbose";
-pub const ARG_RANDOMIZE: &str = "randomize";
 pub const ARG_CONCURRENT_HOSTS: &str = "concurrent-hosts";
 
 /// Current version
@@ -133,11 +132,6 @@ pub fn build_commandline_args() -> clap::Command<'static> {
             .default_value("256")
             .required(false)
             .help("Maximum number of bytes to read when reading banner from open port")
-        ).arg(clap::Arg::new(ARG_RANDOMIZE)
-            .long(ARG_RANDOMIZE)
-            .takes_value(false)
-            .required(false)
-            .help("Randomize the order in which the hosts and ports are scanned")
     )
 }
 
@@ -362,13 +356,6 @@ where
     deserialize_type(des, ARG_READ_BANNER_SIZE)
 }
 
-fn deserialize_randomize<'de, D>(des: D) -> Result<Option<bool>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_type(des, ARG_VERBOSE)
-}
-
 /// Configuration parameters parsed from command line or JSON file
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -426,8 +413,6 @@ pub struct Config {
     read_banner_timeout: Option<Duration>,
     #[serde(default, deserialize_with = "deserialize_verbose")]
     verbose: Option<bool>,
-    #[serde(default, deserialize_with = "deserialize_randomize")]
-    randomize: Option<bool>,
 }
 
 /// helper for parsing a value from command line parameter
@@ -482,7 +467,6 @@ impl TryFrom<clap::ArgMatches> for Config {
         })?;
         let read_banner = Some(value.is_present(ARG_READ_BANNER));
         let verbose = Some(value.is_present(ARG_VERBOSE));
-        let randomize = Some(value.is_present(ARG_RANDOMIZE));
 
         Ok(Config {
             target,
@@ -498,7 +482,6 @@ impl TryFrom<clap::ArgMatches> for Config {
             read_banner_size,
             read_banner_timeout,
             verbose,
-            randomize,
         })
     }
 }
@@ -547,7 +530,6 @@ impl Config {
             try_count: self.try_count.unwrap(),
             read_banner_size,
             read_banner_timeout,
-            randomize: self.randomize.unwrap_or(false),
         }
     }
 
@@ -633,13 +615,6 @@ impl Config {
                 self.verbose.or(Some(false))
             }
         };
-        let randomize = {
-            if matches.is_present(ARG_RANDOMIZE) {
-                Some(true)
-            } else {
-                self.randomize.or(Some(false))
-            }
-        };
 
         Ok(Config {
             target,
@@ -655,7 +630,6 @@ impl Config {
             read_banner_size,
             read_banner_timeout,
             verbose,
-            randomize,
         })
     }
 
@@ -934,7 +908,6 @@ mod tests {
                 read_banner_size: Some(128),
                 read_banner_timeout: Some(Duration::from_millis(100)),
                 verbose: Some(false),
-                randomize: Some(false),
             };
 
             let m = build_commandline_args()
@@ -1100,7 +1073,6 @@ mod tests {
             read_banner_size: None,
             read_banner_timeout: None,
             verbose: None,
-            randomize: None,
         };
 
         let empty_cmdline: Vec<&str> = Vec::new();
@@ -1121,7 +1093,6 @@ mod tests {
         assert!(new_cfg.read_banner_size.is_some());
         assert!(new_cfg.read_banner_timeout.is_some());
         assert!(new_cfg.verbose.is_some());
-        assert!(new_cfg.randomize.is_some());
 
         // no values should be set for fields we have no proper defaults for
         assert!(new_cfg.target.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,7 +176,7 @@ async fn main() {
         .spawn(collect_results(rx, verbose))
     {
         let scan = scanner::Scanner::create(params, stop.clone());
-        let (infos, scanstatus) = col.join(scan.scan(cfg.get_range().unwrap(), tx)).await;
+        let (infos, scanstatus) = col.join(scan.scan(range, tx)).await;
         if let Err(e) = scanstatus {
             if e.is_fatal() {
                 // fatal error, results can not be trusted.

--- a/src/output.rs
+++ b/src/output.rs
@@ -3,6 +3,7 @@ use async_std::prelude::*;
 use serde::ser::SerializeMap;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::fmt::{self, Display};
 use std::net::IpAddr;
 use std::time::Duration;
@@ -41,12 +42,10 @@ impl Display for Banners {
         let mut builder = String::new();
         builder.push_str("\n\t Banners received from open ports:\n");
         for (port, b) in &self.values {
-            match std::str::from_utf8(b) {
-                Ok(s) => builder.push_str(&format!("\t\tPort: {} \"{}\"", port, s)),
-                Err(_e) => {
-                    builder.push_str(&format!("\t\tPort: {}: {} bytes of data", port, b.len()))
-                }
-            }
+            let _ = match std::str::from_utf8(b) {
+                Ok(s) => write!(builder, "\t\tPort: {} \"{}\"", port, s),
+                Err(_e) => write!(builder, "\t\tPort: {}: {} bytes of data", port, b.len()),
+            };
         }
         write!(f, "{}", builder)
     }
@@ -161,25 +160,28 @@ impl fmt::Display for HostInfo {
                 "Up"
             }
         };
-        pstr.push_str(&format!(
+        let _ = write!(
+            pstr,
             "{} is {} \n\t{} Open Ports:",
             self.address,
             status,
             self.open_ports.len()
-        ));
+        );
         for port in &self.open_ports {
-            pstr.push_str(&format!(" {}", port))
+            let _ = write!(pstr, " {}", port);
         }
-        pstr.push_str(&format!(
+        let _ = write!(
+            pstr,
             "\n\t{} ports closed and {} filtered",
             self.closed_count, self.filtered_count
-        ));
+        );
         let delays = self.get_delays();
-        pstr.push_str(&format!(
+        let _ = write!(
+            pstr,
             " (delays: min {}ms, max {}ms)",
             delays.0.as_millis(),
             delays.1.as_millis()
-        ));
+        );
 
         if !self.banners.is_empty() {
             pstr.push_str(&self.banners.to_string());

--- a/src/ports.rs
+++ b/src/ports.rs
@@ -137,6 +137,10 @@ impl PortRange {
         }
         panic!("requested index out of bounds")
     }
+
+    pub fn port_iter(&self) -> impl Iterator<Item = u16> + '_ {
+        (0..self.port_count() as usize).map(|i| self.get(i))
+    }
 }
 
 /// Parse a single port range, min-max (inclusive).

--- a/src/range.rs
+++ b/src/range.rs
@@ -7,7 +7,7 @@ use crate::ports::PortRange;
 /// HostRange holds ports to scan for each host in `ScanRange`.
 pub struct HostRange {
     pub host: IpAddr,
-    pub ports: PortRange,
+    // pub ports: PortRange,
 }
 
 ///ScanRnge contains information which hosts and ports on those hosts to scan
@@ -15,7 +15,7 @@ pub struct HostRange {
 /// scan. `HostRange` can be used to get iterators for ports to scan on
 /// that host.
 pub struct ScanRange<'a> {
-    ports: PortRange,
+    pub ports: PortRange,
     addrs: &'a [IpCidr],
     excludes: &'a [IpAddr],
 }
@@ -48,7 +48,7 @@ impl ScanRange<'_> {
             .filter(move |a| !self.excludes.contains(a))
             .map(move |a| HostRange {
                 host: a,
-                ports: self.ports.clone(),
+                // ports: self.ports.clone(),
             });
     }
 }

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -316,7 +316,6 @@ pub struct ScanParameters {
     pub try_count: usize,                // number of times to try if there is no response
     pub read_banner_size: Option<usize>, // number of bytes to read if connection is established
     pub read_banner_timeout: Option<Duration>, // how long to wait for banner
-    pub randomize: bool,
 }
 
 impl Default for ScanParameters {
@@ -330,7 +329,6 @@ impl Default for ScanParameters {
             try_count: 2,
             read_banner_size: None,
             read_banner_timeout: None,
-            randomize: false,
         }
     }
 }
@@ -383,11 +381,8 @@ impl Scanner {
         let atx = Arc::new(tx);
         let host_chunks = ChunkIter::new(range.hosts(), self.params.concurrent_hosts);
         let mut ports = range.ports.port_iter().collect::<Vec<u16>>();
-
-        if self.params.randomize {
-            let mut rng = rand::thread_rng();
-            ports.shuffle(&mut rng);
-        }
+        let mut rng = rand::thread_rng();
+        ports.shuffle(&mut rng);
 
         // return value, this gets set from task if fatal error occurs and w
         // need to indicate the error. Needs to be protected by mutex since
@@ -498,7 +493,6 @@ mod tests {
             try_count: 2,
             read_banner_size: None,
             read_banner_timeout: None,
-            randomize: false,
         };
 
         let mut map = HashMap::new();

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -311,7 +311,6 @@ pub struct ScanParameters {
     pub wait_timeout: Duration,          // Duration to wait for responses
     pub concurrent_scans: usize,         // number of concurrent tasks to run
     pub concurrent_hosts: usize,         // number of hosts to scan at the same time
-    pub enable_adaptive_timing: bool,    // should adaptive timeout be used
     pub retry_on_error: bool,            // should we retry on network error
     pub try_count: usize,                // number of times to try if there is no response
     pub read_banner_size: Option<usize>, // number of bytes to read if connection is established
@@ -324,7 +323,6 @@ impl Default for ScanParameters {
             wait_timeout: DEFAULT_CONNECTION_TIMEOUT,
             concurrent_scans: 100,
             concurrent_hosts: 100,
-            enable_adaptive_timing: false,
             retry_on_error: false,
             try_count: 2,
             read_banner_size: None,
@@ -488,7 +486,6 @@ mod tests {
             wait_timeout: Duration::from_millis(100),
             concurrent_scans: 2,
             concurrent_hosts: 2,
-            enable_adaptive_timing: false,
             retry_on_error: false,
             try_count: 2,
             read_banner_size: None,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use async_std::{channel, task};
 use async_std::sync::Arc;
+use async_std::{channel, task};
 
 /// Simple counting semaphore.
 /// Use Semaphore::new() to get new instance with given capacity,
@@ -35,7 +35,7 @@ impl Semaphore {
 
     /// Wait for Semaphore to be empty, that is, wait for all handles to
     /// be signaled.
-    pub async fn wait_empty(&self)  {
+    pub async fn wait_empty(&self) {
         while !self.ch.is_empty() {
             task::sleep(Duration::from_millis(100)).await;
         }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1,4 +1,6 @@
-use async_std::channel;
+use std::time::Duration;
+
+use async_std::{channel, task};
 use async_std::sync::Arc;
 
 /// Simple counting semaphore.
@@ -28,6 +30,14 @@ impl Semaphore {
         trace!("waited, c={}", self.ch.len());
         SemHandle {
             sig: self.sig.clone(),
+        }
+    }
+
+    /// Wait for Semaphore to be empty, that is, wait for all handles to
+    /// be signaled.
+    pub async fn wait_empty(&self)  {
+        while !self.ch.is_empty() {
+            task::sleep(Duration::from_millis(100)).await;
         }
     }
 }


### PR DESCRIPTION
 * Remove duplicates from ports
   *  If same port is given multiple times, it is scanned only once.
 * Simplify port iterator
 * Start scanning for multiple hosts in parallel instead of focusing scanning on single host at a time.
 * Add option `--concurrent-hosts` to limit the number of hosts to scan at the same time. 