### PR TITLE
Signal semaphore if host is detected to be down

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -427,6 +427,7 @@ impl Scanner {
             let semh = self.sem.wait().await;
             if !ctx.keep_running() {
                 // host down, no need to continue further
+                semh.signal();
                 break;
             }
             let handle = task::spawn(scan_port_stripe(


### PR DESCRIPTION
Fixes deadlock which occurs when a lot of hosts on scanned network are down.